### PR TITLE
chore(dev): remove python venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,9 @@ UVICORN = $(VENV)/bin/uvicorn
 RUFF = $(VENV)/bin/ruff
 
 install:
-	uv venv
 	uv pip install -r requirements.txt
 
 install-dev:
-	uv venv
 	uv pip install -r requirements-dev.txt
 
 start:

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,10 @@ UVICORN = $(VENV)/bin/uvicorn
 RUFF = $(VENV)/bin/ruff
 
 install:
-	python -m venv $(VENV)
 	uv venv
 	uv pip install -r requirements.txt
 
 install-dev:
-	python -m venv $(VENV)
 	uv venv
 	uv pip install -r requirements-dev.txt
 


### PR DESCRIPTION
No longer necessary since we’re using `uv`.
